### PR TITLE
rtl-sdr: Fix dependency and enable DETACH_KERNEL_DRIVER.

### DIFF
--- a/recipes/rtl-sdr.lwr
+++ b/recipes/rtl-sdr.lwr
@@ -1,6 +1,7 @@
 category: common
-depends: gnuradio 
+depends: libusb
 source: git://git://git.osmocom.org/rtl-sdr
 gitbranch: master
+var config_opt = " -DDETACH_KERNEL_DRIVER=ON "
 inherit: cmake
 


### PR DESCRIPTION
I don't know why gnuradio was listed as dependency. Clearly rtl-sdr does not depend on it.
I also enabled automatic detachment of the kernel driver, since most recent kernels will have the TV driver loaded when the dongle is plugged in preventing librtlsdr to claim the interface.
