### PR TITLE
hackrf: Use official repository and remove gnuradio dependency.

### DIFF
--- a/recipes/hackrf.lwr
+++ b/recipes/hackrf.lwr
@@ -1,8 +1,7 @@
-depends: gnuradio git cmake libusb 
+depends: git cmake libusb
 category: common
-source: git://https://github.com/Hoernchen/hackrf.git
-#gitbranch: master
-gitbranch: siclock
+source: git://https://github.com/mossmann/hackrf.git
+gitbranch: master
 inherit: cmake
 configuredir: host/build
 makedir: host/build


### PR DESCRIPTION
Being a driver library, hackrf does not depend on gnuradio.
The official git repository is at mossmann/hackrf.git
