### PR TITLE
Update link to UHD git repository.

### DIFF
--- a/recipes/uhd.lwr
+++ b/recipes/uhd.lwr
@@ -19,7 +19,7 @@
 
 category: common
 depends: make swig python libusb git cmake cheetah boost gsl numpy cppunit fftw
-source: git://git://code.ettus.com/ettus/uhd.git
+source: git://https://github.com/EttusResearch/uhd.git
 gitbranch: master
 inherit: cmake
 configuredir: host/build


### PR DESCRIPTION
Ettus no longer pushes commits to the original repository.
