### PR TITLE
Switching gr-ais recipe to bistromath repo.  Builds for 3.7 now.

### DIFF
--- a/recipes/gr-ais.lwr
+++ b/recipes/gr-ais.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: gnuradio gr-compat
-source: git://https://github.com/chgans/gr-ais.git
+depends: gnuradio
+source: git://https://github.com/bistromath/gr-ais.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
gr-ais had a recipe that pulled against an old fork of Nick's gr-ais module.  I switched it to Nick's so that it will now build against 3.7
