### PR TITLE
Fixing naming bug

### DIFF
--- a/recipes/pyqt4-dev-tools.lwr
+++ b/recipes/pyqt4-dev-tools.lwr
@@ -18,5 +18,5 @@
 #
 
 category: baseline
-depends: python-qt4
+depends: pyqt4
 satisfy_deb: pyqt4-dev-tools


### PR DESCRIPTION
PyQt4 deb (python-qt4) and recipe name (pyqt4) are different.

Slipped my attention, sorry.
