### PR TITLE
gr-specest now uses the master branch for GR3.7 compatibility

### DIFF
--- a/recipes/gr-specest.lwr
+++ b/recipes/gr-specest.lwr
@@ -20,6 +20,6 @@
 category: common
 depends: gnuradio
 source: git://https://github.com/kit-cel/gr-specest.git
-gitbranch: 37
+gitbranch: master
 inherit: cmake
 


### PR DESCRIPTION
gr-specest has recently been ported to GR 3.7. Therefore all new development will happen on the master branch and the GR 3.6 stuff is now on the GR36 branch. I changed the gr-specest recipe to reflect that.
