### PR TITLE
Adding "airprobe" as a dependency for gr-osmosdr.

### DIFF
--- a/recipes/gr-osmosdr.lwr
+++ b/recipes/gr-osmosdr.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: uhd rtl-sdr osmo-sdr hackrf gnuradio gr-iqbal bladeRF
+depends: uhd rtl-sdr osmo-sdr hackrf gnuradio gr-iqbal bladeRF airspy
 source: git://git://git.osmocom.org/gr-osmosdr
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
gr-osmosdr compiles again with airprobe present since issue 4 ( https://github.com/airspy/host/issues/4 ) was fixed.
Tested on Debian 7.0.4 .
