### PR TITLE
gr-bluetooth repository has moved

### DIFF
--- a/recipes/gr-bluetooth.lwr
+++ b/recipes/gr-bluetooth.lwr
@@ -19,6 +19,6 @@
 
 category: common
 depends: gnuradio gr-compat
-source: git://https://github.com/dominicgs/gr-bluetooth.git
+source: git://https://github.com/greatscottgadgets/gr-bluetooth.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
It currently doesn't build and it depends on libBTBB, for which I can write a recipe, but for now it has moved from my personal account to the GSG organisation.
