### PR TITLE
Update Armadillo to 4.400.1 as gnss-sdr requires it.

### DIFF
--- a/recipes/armadillo.lwr
+++ b/recipes/armadillo.lwr
@@ -19,6 +19,6 @@
 
 category: baseline
 depends: wget cmake blas lapack
-source: wget://http://sourceforge.net/projects/arma/files/armadillo-4.320.0.tar.gz
+source: wget://http://sourceforge.net/projects/arma/files/armadillo-4.400.1.tar.gz
 var config_opt = " -DINSTALL_LIB_DIR=$prefix/lib "
 inherit: cmake


### PR DESCRIPTION
The only other package that depends on Armadillo (gr-baz) also builds
fine with 4.400.1.
