### PR TITLE
Add support for gqrx-digital fork of gqrx

### DIFF
--- a/recipes/gqrx-digital.lwr
+++ b/recipes/gqrx-digital.lwr
@@ -1,0 +1,41 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: gnuradio gr-osmosdr pulseaudio qt4 libosmocore osmo-tetra libshout gr-dsd
+source: git://https://github.com/kantooon/gqrx_fork.git
+gitbranch: digital
+inherit: empty
+
+configure {
+    qmake -recursive BOOST_SUFFIX= INCLUDEPATH="../../gr-dsd/dsd $prefix/include/osmo-tetra $prefix/include/dsd $prefix/include ../../osmo-tetra/src" DEPENDPATH="$prefix/lib $prefix/include/dsd" LIBS+="-Xlinker -zmuldefs"
+}
+
+make {
+    make -j$makewidth 
+}
+
+install {
+    cp gqrx $prefix/bin/
+}
+
+uninstall {
+    rm $prefix/bin/gqrx
+}
+

--- a/recipes/gr-dsd.lwr
+++ b/recipes/gr-dsd.lwr
@@ -1,0 +1,44 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: mbelib gnuradio libsndfile
+source: git://https://github.com/argilo/gr-dsd.git
+gitbranch: master
+inherit: cmake
+
+install {
+	make install
+
+	mkdir -p $prefix/include/dsd
+
+	cp -v ../dsd/dsd.h $prefix/include
+	cp -v ../dsd/config.h $prefix/include
+	cp -v ../include/dsd_block_ff.h $prefix/include/dsd
+	cp -v ../include/dsd_api.h $prefix/include/dsd
+}
+
+uninstall {
+	make uninstall
+
+	rm -v $prefix/include/dsd.h || true
+	rm -v $prefix/include/config.h || true
+	rm -v $prefix/include/dsd/dsd_block_ff.h || true
+	rm -v $prefix/include/dsd/dsd_api.h || true
+}

--- a/recipes/libosmocore.lwr
+++ b/recipes/libosmocore.lwr
@@ -1,0 +1,32 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+# FIXME: recommends: doxygen
+
+category: common
+depends: libtool automake
+source: git://git://git.osmocom.org/libosmocore.git
+gitbranch: master
+inherit: autoconf
+
+configure {
+    autoreconf -i
+    ./configure --prefix=$prefix $config_opt
+}
+

--- a/recipes/libshout.lwr
+++ b/recipes/libshout.lwr
@@ -1,0 +1,22 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+satisfy_deb: libshout3-dev
+satisfy_rpm: libshout-devel

--- a/recipes/libsndfile.lwr
+++ b/recipes/libsndfile.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+satisfy_deb: libsndfile-dev
+satisfy_rpm: libsndfile-devel
+source: wget://http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.25.tar.gz
+inherit: autoconf

--- a/recipes/mbelib.lwr
+++ b/recipes/mbelib.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends: 
+source: git://https://github.com/szechyjs/mbelib.git
+gitbranch: master
+inherit: cmake

--- a/recipes/osmo-tetra.lwr
+++ b/recipes/osmo-tetra.lwr
@@ -1,0 +1,43 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+source: git://https://github.com/brmlab/osmo-tetra.git
+gitbranch: master
+#inherit: autoconf
+
+make {
+    cd src
+    export LD_LIBRARY_PATH=$prefix/lib/:$prefix/lib64/
+    make
+}
+
+install {
+	cp -v src/libosmo-tetra-mac.a $prefix/lib
+	cp -v src/libosmo-tetra-phy.a $prefix/lib
+	ldconfig -C $prefix/etc/ld.so.cache $prefix/lib	
+	cd src
+	find . -name '*.h' | cpio -pdm $prefix/include/osmo-tetra
+}
+
+uninstall {
+	rm $prefix/lib/libosmo-tetra-mac.a
+	rm $prefix/lib/libosmo-tetra-phy.a
+}


### PR DESCRIPTION
This pull adds recipes required for building gqrx-digital fork, which contains DSD integration in GQRX. Available at https://github.com/argilo/gqrx_fork/tree/digital

Includes recipes for dependency packages: gr-dsd, libosmo, libshout, libsndfile, mbelib, osmo-tetra

Just want to put this out there in case anybody else is looking for something similar... It's a pretty cool fork of gqrx that helps avoid a lot of manual work, chaining together audio monitors, etc.
