### PR TITLE
libusb: Require at least libusb-1.0 version 1.0.9.

### DIFF
--- a/recipes/libusb.lwr
+++ b/recipes/libusb.lwr
@@ -20,6 +20,6 @@
 depends: wget
 category: baseline
 source: wget://http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.9/libusb-1.0.9.tar.bz2
-satisfy_deb: libusb-1.0-0-dev
-satisfy_rpm: libusb-devel >= 1.0
+satisfy_deb: libusb-1.0-0-dev >= 1.0.9
+satisfy_rpm: libusb-devel >= 1.0.9
 inherit: autoconf


### PR DESCRIPTION
This fixes the following build error (see issue #76):

  /usr/local/lib/libuhd.so: undefined reference to `libusb_error_name'

The libusb_error_name() API call was added in 1.0.9.
