### PR TITLE
libsndfile: Fix satisfy_deb line.

### DIFF
--- a/recipes/libsndfile.lwr
+++ b/recipes/libsndfile.lwr
@@ -18,7 +18,7 @@
 #
 
 category: baseline
-satisfy_deb: libsndfile-dev
+satisfy_deb: libsndfile-dev || libsndfile1-dev
 satisfy_rpm: libsndfile-devel
 source: wget://http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.25.tar.gz
 inherit: autoconf


### PR DESCRIPTION
libsndfile-dev is a virtual package ("apt-get install libsndfile-dev" will
actually install libsndfile1-dev). The current code cannot properly
handle/detect it as being available ("apt-cache show" output is different
from what it expects), hence it'll try to build from source instead.

Fix this by adding libsndfile1-dev as alternative.
