### PR TITLE
gr-specest: added dependencies to recipe

### DIFF
--- a/recipes/gr-specest.lwr
+++ b/recipes/gr-specest.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: gnuradio
+depends: gnuradio gfortran liblapack-dev libblas-dev
 source: git://https://github.com/kit-cel/gr-specest.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Added missing dependencies (gfortran, liblapack-dev, libblas-dev) to the recipe. As I'm not a pybombs user, it's untested.
