### PR TITLE
gr-specest: Fix dependencies.

### DIFF
--- a/recipes/gr-specest.lwr
+++ b/recipes/gr-specest.lwr
@@ -18,7 +18,7 @@
 #
 
 category: common
-depends: gnuradio gfortran liblapack-dev libblas-dev
+depends: gnuradio gfortran lapack blas
 source: git://https://github.com/kit-cel/gr-specest.git
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Fix two dependencies to refer to the correct recipe names
(instead of distro-specific package names).
