### PR TITLE
Update osmo-sdr recipe to match current git layout

### DIFF
--- a/recipes/osmo-sdr.lwr
+++ b/recipes/osmo-sdr.lwr
@@ -23,8 +23,3 @@ satisfy_deb: osmo-sdr && libosmosdr-dev
 source: git://git://git.osmocom.org/osmo-sdr.git
 gitbranch: master
 inherit: cmake
-
-configuredir: software/libosmosdr/build
-makedir: software/libosmosdr/build
-installdir: software/libosmosdr/build
-


### PR DESCRIPTION
This modification is necessary for this package to compile.
