### PR TITLE
Fixed SVN Repository URL for gr-pocsag recipe.

### DIFF
--- a/recipes/gr-pocsag.lwr
+++ b/recipes/gr-pocsag.lwr
@@ -19,6 +19,6 @@
 
 category: common
 depends: gnuradio gr-compat
-source: svn://https://www.cgran.org/cgran/projects/gr-pocsag/trunk
+source: svn://https://www.cgran.org/svn/projects/gr-pocsag/trunk
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
It seems cgran.org experienced some issues and is starting from scratch. The repository location has changed.