### PR TITLE
remove two debug print statements

### DIFF
--- a/mod_pybombs/pybombs_ops.py
+++ b/mod_pybombs/pybombs_ops.py
@@ -218,7 +218,6 @@ def config_get(k):
 
 def config_set(k,v):
     config.set("config",k,v);
-    print "value updated"
 
 def clean(kl):
     if(type(kl) == str):

--- a/mod_pybombs/pybombs_ops.py
+++ b/mod_pybombs/pybombs_ops.py
@@ -214,7 +214,7 @@ def config_print():
         print p[0] + " = " +  p[1];
 
 def config_get(k):
-    print config.get("config",k);
+    config.get("config",k);
 
 def config_set(k,v):
     config.set("config",k,v);

--- a/pybombs
+++ b/pybombs
@@ -122,7 +122,7 @@ if len(args) > 0:
     else:
         pybombs_ops.config_set("static","False")
 try:
-    print pybombs_ops.config_get("static")
+    pybombs_ops.config_get("static")
 except:
     pybombs_ops.config_set("static","False")
 


### PR DESCRIPTION
Two print statements, which are possible for quick debug purposes, are left. It gives "False" and "value updated" output when running. They are removed in this commit.