### PR TITLE
don't wipe out the user's chosen config_opt

### DIFF
--- a/templates/cmake.lwt
+++ b/templates/cmake.lwt
@@ -22,7 +22,7 @@ makedir: build
 installdir: build
 depends: cmake
 
-var config_opt = ""
+# var config_opt = "-DYOUR_OPTIONS=HERE"
 
 configure { 
     CC=$cc CXX=$cxx cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt


### PR DESCRIPTION
If you add a bit of debug print to the template you see this change

Before:
    echo I am the cmake template - my config opt is ""
    CC=gcc CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/home/gnuradio

After
    echo I am the cmake template - my config opt is " -DINSTALL_UDEV_RULES=OFF"
    CC=gcc CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/home/gnuradio  -DINSTALL_UDEV_RULES=OFF