### PR TITLE
add a handler for "description:"

### DIFF
--- a/app_store.py
+++ b/app_store.py
@@ -48,7 +48,7 @@ class AppList(QtGui.QWidget):
     def cb(self):
         self._cb();
 
-    def addButton(self, name, callback):
+    def addButton(self, name, callback, descr):
         self._cb = callback;
         pkgimg = "img/" + name + ".png";
         if os.path.exists(pkgimg):
@@ -59,6 +59,8 @@ class AppList(QtGui.QWidget):
         icon = QtGui.QIcon(pixmap);
         button = QtGui.QToolButton();
         action = QtGui.QAction( icon, str(name), self );
+        if descr is not None:
+            action.setToolTip(descr)
         action.setStatusTip('Install App')
         button.setDefaultAction(action);
         button.setToolButtonStyle(Qt.ToolButtonTextUnderIcon);
@@ -213,7 +215,7 @@ class ASMain(QtGui.QWidget):
                 else:
                     cbs[c][p] = Installer(self, p);
                     pcidx = 2*cidx;
-                tabw[pcidx].addButton(p, cbs[c][p].cb);
+                tabw[pcidx].addButton(p, cbs[c][p].cb, global_recipes[p].description);
 
         self.cbs = cbs;
 

--- a/mod_pybombs/pybombs_ops.py
+++ b/mod_pybombs/pybombs_ops.py
@@ -200,6 +200,8 @@ def pkginfo(pn):
 
     print "Package Info for:    %s"%(pkg.name);
     print "Package Category:    %s"%(pkg.category);
+    if pkg.description:
+        print "Package Description:%s"%(pkg.description);
     print "Package Deps:        %s"%(str(pkg.depends));
     
     print "";

--- a/mod_pybombs/recipe.py
+++ b/mod_pybombs/recipe.py
@@ -233,6 +233,11 @@ class recipescanner(Scanner):
             print "Setting category: "+c;
         self.recipe.category = c;
 
+    def description_set(self,d):
+        if debug_en:
+            print "Setting description: "+d;
+        self.recipe.description = d;
+
     def mainstate(self,a):
         self.begin("")
 
@@ -373,6 +378,7 @@ class recipescanner(Scanner):
     lexicon = Lexicon([
         (Str("category:"), Begin("cat")),
         (Str("depends:"), Begin("deplist")),
+        (Str("description:"), Begin("descr")),
         (Str("inherit:"), Begin("inherit")),
         (Str("configuredir:"), Begin("configuredir")),
         (Str("makedir:"), Begin("makedir")),
@@ -414,6 +420,9 @@ class recipescanner(Scanner):
             ]),
         State('cat', [
             (sep, IGNORE), (pkgname, category_set), (eol, mainstate),
+            ]),
+        State('descr', [
+            (sep, IGNORE), (pkgname, description_set), (eol, mainstate),
             ]),
         State('inherit', [
             (sep, IGNORE), (pkgname, inherit), (eol, mainstate),
@@ -513,6 +522,7 @@ class recipe:
         self.name = name;
         self.clearpkglist();
         self.depends = [];
+        self.description = "";
         self.satisfy_deb = None;
         self.satisfy_rpm = None;
         self.source = [];

--- a/mod_pybombs/recipe.py
+++ b/mod_pybombs/recipe.py
@@ -363,6 +363,7 @@ class recipescanner(Scanner):
     number = Rep1(digit)
     space = Any(" \t\n")
     rspace = Rep(space)
+    freetext = Rep(letter | digit | Any("+@$-._:/()#%[]=' ") | Any('"'))
     comment = Str("{") + Rep(AnyBut("}")) + Str("}")
     sep = Any(", :/");
     eol = Str("\r\n")|Str("\n")|Eof
@@ -422,7 +423,7 @@ class recipescanner(Scanner):
             (sep, IGNORE), (pkgname, category_set), (eol, mainstate),
             ]),
         State('descr', [
-            (sep, IGNORE), (pkgname, description_set), (eol, mainstate),
+            (sep, IGNORE), (freetext, description_set), (eol, mainstate),
             ]),
         State('inherit', [
             (sep, IGNORE), (pkgname, inherit), (eol, mainstate),
@@ -522,7 +523,7 @@ class recipe:
         self.name = name;
         self.clearpkglist();
         self.depends = [];
-        self.description = "";
+        self.description = None;
         self.satisfy_deb = None;
         self.satisfy_rpm = None;
         self.source = [];
@@ -850,4 +851,3 @@ class recipe:
         mkchdir(topdir + "/src/" + self.name + "/" + self.installdir)
         st = bashexec(self.scanner.var_replace_all(self.scr_verify));
         self.check_stat(st, "Verify");
-


### PR DESCRIPTION
This allows recipes to have a new "description:" property, which I need to make pybombs display a brief synopsis of each module/recipe.

Needed for gnuradio/recipes#31