### PR TITLE
add recipe description to output of "pybombs list"

### DIFF
--- a/mod_pybombs/pybombs_ops.py
+++ b/mod_pybombs/pybombs_ops.py
@@ -191,6 +191,9 @@ def pkglist():
                     state = inv.state(pkg);
                     satisfier = "inventory"
                 print "%25s %12s %10s %20s %s"%( pkg, state, satisfier, version, source );
+            descr = global_recipes[pkg].description
+            if descr:
+                print "\t%s\n" % descr
 
 def pkginfo(pn):
     try:


### PR DESCRIPTION
Example output:

                 gnuradio    installed  inventory 55d8f482f5acf33b8f629556a4fa5019908bb4be git://http://www.gnuradio.org/git/gnuradio.git
                 gr-acars                    None
                gr-acars2    installed  inventory adcc989e5b44633326a52d504b51bb735f371ae1 git://https://github.com/antoinet/gr-acars2.git
	 GNU Radio processing block for ACARS transmissions

                  gr-adsb                    None
	 GNU Radio ADSB decoder and framer

             gr-air-modes                    None
	 Gnuradio Mode-S/ADS-B decoder