### PR TITLE
Enable .tar.xz files to be extracted in pybombs

### DIFF
--- a/mod_pybombs/fetch.py
+++ b/mod_pybombs/fetch.py
@@ -166,5 +166,5 @@ class fetcher:
                 os.unlink(fn)
                 return True
         else:
-            print "unknown compression type?"%(fn)
+            print "unknown compression type for file %s?"%(fn)
             return False

--- a/mod_pybombs/fetch.py
+++ b/mod_pybombs/fetch.py
@@ -145,10 +145,10 @@ class fetcher:
 
     def extract(self,fn):
         tarflags = {
-            r'.tar.gz':'z',
-            r'.tgz':'z', 
-            r'.bz2':'j',
-            r'.xz':'J'
+            r'.*\.tar\.gz':'z',
+            r'.*\.tgz':'z', 
+            r'.*\.bz2':'j',
+            r'.*\.xz':'J'
         }
         os.chdir(topdir + "/src/")
         print "Extract %s"%(fn)


### PR DESCRIPTION
.xz compression (which is pretty common) is not supported by pybombs. 

I refactored the extract method to deduplicate cloned code and to handle 3 kinds of compression compatible with tar.

I also fixed a formatting bug when the filetype wasn't known.