### PR TITLE
Improvements of './pybombs config ...' command

### DIFF
--- a/mod_pybombs/pybombs_ops.py
+++ b/mod_pybombs/pybombs_ops.py
@@ -219,7 +219,7 @@ def config_print():
         print p[0] + " = " +  p[1];
 
 def config_get(k):
-    config.get("config",k);
+    return config.get("config",k);
 
 def config_set(k,v):
     config.set("config",k,v);

--- a/pybombs
+++ b/pybombs
@@ -212,6 +212,7 @@ elif(cmd == "config"):
         print args[0]+' = '+pybombs_ops.config_get(args[0])
     elif(len(args) == 2):
         pybombs_ops.config_set(args[0], args[1])
+        pybombs_ops.config_write(config)
     else:
         parser.error("Command 'config' accepts at most 2 arguments")
 

--- a/pybombs
+++ b/pybombs
@@ -209,7 +209,7 @@ elif(cmd == "config"):
     if(len(args) == 0):
         pybombs_ops.config_print()
     elif(len(args) == 1):
-        pybombs_ops.config_get(args[0])
+        print args[0]+' = '+pybombs_ops.config_get(args[0])
     elif(len(args) == 2):
         pybombs_ops.config_set(args[0], args[1])
     else:


### PR DESCRIPTION
Changes in order to make following pybombs commands work:
-./pybobms config \<k\>  - now prints value of \<k\>
-./pybombs config \<k\> \<v\> - now stores value \<v\> of key \<k\> to config.dat file