### PR TITLE
Fixed issue where pybombs would crash on configuration setup

### DIFF
--- a/mod_pybombs/cfg.py
+++ b/mod_pybombs/cfg.py
@@ -22,6 +22,7 @@
 
 import ConfigParser;
 import os, sys;
+from subprocess import Popen, PIPE
 
 
 def config_init(cfg, reconfig=False):
@@ -67,6 +68,8 @@ def config_init(cfg, reconfig=False):
                 vals[kn] = os.environ.get("USER");
         if kn == "prefix":
             pwd = os.environ.get("PWD");
+            if pwd is None:
+                pwd = Popen('pwd', stdout=PIPE).communicate()[0].strip()
             if os.path.basename(pwd)=="pybombs":
                 vals[kn] = os.path.join(os.path.dirname(pwd), "target")
 


### PR DESCRIPTION
Attempting to configure pybombs on a new Ubuntu 14.4 install (as recommended in the [RTL-SDR tutorial](http://www.rtl-sdr.com/rtl-sdr-tutorial-analyzing-gsm-with-airprobe-and-wireshark/)) leads to the following error, even after all the packages have been updated:

```
VirtualBox:~/Source/pybombs$ sudo ./pybombs config
Initializing config file...
Username for GIT access
gituser [root]:
Directory of git cache repository
gitcache []:
Options to always pass to git clones (--depth=1 or --single-branch will speed up clones)
gitoptions []:
Install Prefix
Traceback (most recent call last):
  File "./pybombs", line 25, in <module>
    from mod_pybombs import verbosity as v
  File "/home/elephanthunter/Source/pybombs/mod_pybombs/__init__.py", line 22, in <module>
    from globals import *;
  File "/home/elephanthunter/Source/pybombs/mod_pybombs/globals.py", line 48, in <module>
    config_init(config);
  File "/home/elephanthunter/Source/pybombs/mod_pybombs/cfg.py", line 70, in config_init
    if os.path.basename(pwd)=="pybombs":
  File "/usr/lib/python2.7/posixpath.py", line 121, in basename
    i = p.rfind('/') + 1
AttributeError: 'NoneType' object has no attribute 'rfind'
```

I've included a simple fix that attempts a workaround in case the function call does not return the correct path.