### PR TITLE
Do not access 'deps_only' in 'update' handler

### DIFF
--- a/pybombs/commands/install.py
+++ b/pybombs/commands/install.py
@@ -140,7 +140,7 @@ class Install(CommandBase):
             if pkg in install_cache:
                 continue
             install_cache.append(pkg)
-            if self.args.deps_only and pkg in self.args.packages:
+            if self.cmd == 'install' and self.args.deps_only and pkg in self.args.packages:
                 self.log.debug("Skipping `{0}' because only deps are requested.")
                 continue
             if self.pm.installed(pkg):


### PR DESCRIPTION
Crash when accessing deps_only in update handler. The option is only defined in the install handler. Handlers for install and update are implemented by the same code, so add a check.