### PR TITLE
emit useful output when config file is invalid

### DIFF
--- a/pybombs/config_file.py
+++ b/pybombs/config_file.py
@@ -29,10 +29,14 @@ class PBConfigFile(object):
     """
     def __init__(self, filename):
         self._filename = filename
+        self.data = None
         try:
-            self.data = yaml.safe_load(open(filename).read()) or {}
-        except (IOError, OSError):
+            self.data = yaml.safe_load(open(filename).read())
+        except (IOError, OSError) as e:
             self.data = {}
+            pass
+        except Exception as e:
+            print "Error loading %s: %s" % (filename, str(e))
         assert isinstance(self.data, dict)
 
     def get(self):


### PR DESCRIPTION
eg:
    $ env PYTHONPATH=. python pybombs/main.py recipes list
    Error loading /home/ckuethe/.pybombs/config.yml: while scanning for the next token
    found character '\t' that cannot start any token
      in "<string>", line 23, column 1:
    	   	forcebuild: True