### PR TITLE
Modified moved recipes for packager port

### DIFF
--- a/pybombs/recipes/autoconf.lwr
+++ b/pybombs/recipes/autoconf.lwr
@@ -23,4 +23,5 @@ satisfy:
   deb: autoconf >= 2.69
   rpm: autoconf >= 2.69
   pacman: autoconf >= 2.69
+  port: autoconf >= 2.69
 source: wget+http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz

--- a/pybombs/recipes/automake.lwr
+++ b/pybombs/recipes/automake.lwr
@@ -23,4 +23,5 @@ satisfy:
   deb: automake >= 1.14
   rpm: automake >= 1.14
   pacman: automake >= 1.14
+  port: automake >= 1.14
 source: wget+http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz

--- a/pybombs/recipes/python.lwr
+++ b/pybombs/recipes/python.lwr
@@ -24,5 +24,6 @@ satisfy:
   rpm: python-devel >= 2.7
   cmd: python --version >= 2.7
   pacman: python2 >= 2.7
+  port: python27 >= 2.7
 vars:
   config_opt: --enable-shared


### PR DESCRIPTION
Added port packager for the three moved recipes (automake, autoconf, python). This packager is already merged here, so all the recipes in this repo should support it.