### PR TITLE
Added configuration option to disable progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The config.yml files are in YAML format. A typical file looks like this:
 config:
 	satisfy_order: native,src
 	default_prefix: default
+        progress: True
 	# ... more options
 
 # Prefix aliases:

--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -457,6 +457,23 @@ class ConfigManager(object):
             return default
         raise PBException("Invalid configuration key: {}".format(key))
 
+    _truth_dict = { 'False': False,
+                    '0': False,
+                    'OFF': False,
+                    'no': False,
+                    'True': True,
+                    '1': True,
+                    'ON': True,
+                    'yes': True}
+    def get_bool(self, key, default=None):
+        """ Return the value for a given key, converted to boolean """
+        for set_of_vals in reversed(self.cfg_cascade):
+            if key in set_of_vals.keys():
+                return self._truth_dict.get(set_of_vals[key], False)
+        if default is not None:
+            return default
+        raise PBException("Invalid configuration key: {}".format(key))
+
     def keys(self):
         """ Return all currently active config keys """
         all_keys = set()

--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -301,6 +301,7 @@ class ConfigManager(object):
         'cxx': ('', 'C++ Compiler Executable [g++, clang++, icpc, etc]'),
         'makewidth': ('4', 'Concurrent make threads [1,2,4,8...]'),
         'packagers': ('pip,apt-get,yumdnf,port,pacman,pkgconfig,cmd', 'Priority of non-source package managers'),
+        'progress': ('True', 'Show progress when fetching? [True, False]')
     }
     LAYER_DEFAULT = 0
     LAYER_GLOBALS = 1

--- a/pybombs/fetchers/wget.py
+++ b/pybombs/fetchers/wget.py
@@ -29,7 +29,7 @@ import requests
 from pybombs import utils
 from pybombs.fetchers.base import FetcherBase
 
-def _download(url):
+def _download(url, progress = True):
     """
     Do a wget: Download the file specified in url to the cwd.
     Return the filename.
@@ -45,6 +45,8 @@ def _download(url):
                 filesize_dl += len(buff)
             # TODO wrap this into an output processor or at least
             # standardize the progress bars we use
+            if not progress:
+                continue
             if filesize:
                 status = r"%05d kB / %05d kB (%03d%%)" % (
                         int(math.ceil(filesize_dl/1000.)),
@@ -79,7 +81,7 @@ class Wget(FetcherBase):
         - dirname: Put the result into a dir with this name, it'll be a subdir of dest
         - args: Additional args to pass to the actual fetcher
         """
-        filename = _download(url)
+        filename = _download(url, self.cfg.get("progress", True))
         if utils.is_archive(filename):
             # Move archive contents to the correct source location:
             utils.extract_to(filename, dirname)

--- a/pybombs/fetchers/wget.py
+++ b/pybombs/fetchers/wget.py
@@ -81,7 +81,7 @@ class Wget(FetcherBase):
         - dirname: Put the result into a dir with this name, it'll be a subdir of dest
         - args: Additional args to pass to the actual fetcher
         """
-        filename = _download(url, self.cfg.get("progress", True))
+        filename = _download(url, self.cfg.get_bool("progress", True))
         if utils.is_archive(filename):
             # Move archive contents to the correct source location:
             utils.extract_to(filename, dirname)


### PR DESCRIPTION
When remotely running pybombs, progress updates are the opposite of useful.
So: added a config file option to disable them