### PR TITLE
Allow config vars to be used in the source line of recipes.

### DIFF
--- a/pybombs/fetcher.py
+++ b/pybombs/fetcher.py
@@ -113,6 +113,7 @@ class Fetcher(object):
             )
         # Do the fetch
         for src in recipe.source:
+            src = recipe.var_replace_all(src)
             self.log.obnoxious("Trying to fetch {0}".format(src))
             try:
                 if self.fetch_url(src, self.src_dir, recipe.id, recipe.get_dict()):


### PR DESCRIPTION
The original pybombs allowed config vars to be used in the source line of recipes. This commit is intended to add this functionality.

For example, suppose I wanted to create a source line with a standard SSH locator:
```
source: git+<username>@<somemachine>:<reponame>.git
```
However, I don't really want my recipe to contain `<username>`. So I update my recipe to contain:
```
source: git+$somemachineusername@<somemachine>:<reponame>.git
```
Now, anyone who has an account on `<somemachine>` can use my recipe and they shouldn't be using my recipe if they don't.

This pull should fix #343.