### PR TITLE
Add portage package manager to PyBOMBS.

### DIFF
--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -301,7 +301,7 @@ class ConfigManager(object):
         'cc': ('', 'C Compiler Executable [gcc, clang, icc, etc]'),
         'cxx': ('', 'C++ Compiler Executable [g++, clang++, icpc, etc]'),
         'makewidth': ('4', 'Concurrent make threads [1,2,4,8...]'),
-        'packagers': ('pip,apt-get,yumdnf,port,pacman,pkgconfig,cmd', 'Priority of non-source package managers'),
+        'packagers': ('pip,apt-get,yumdnf,port,pacman,portage,pkgconfig,cmd', 'Priority of non-source package managers'),
         'keep_builddir': ('', 'When rebuilding, default to keeping the build directory'),
     }
     LAYER_DEFAULT = 0

--- a/pybombs/packagers/__init__.py
+++ b/pybombs/packagers/__init__.py
@@ -29,3 +29,4 @@ from .pacman import Pacman
 from .dummy import Dummy
 from .source import Source
 from .port import Port
+from .portage import Portage

--- a/pybombs/packagers/portage.py
+++ b/pybombs/packagers/portage.py
@@ -1,0 +1,123 @@
+#
+# Copyright 2016 Free Software Foundation, Inc.
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+"""
+Packager: portage
+"""
+
+import subprocess
+from pybombs.packagers.extern import ExternCmdPackagerBase, ExternPackager
+from pybombs.utils import subproc
+from pybombs.utils import sysutils
+
+class ExternalPortage(ExternPackager):
+    """
+    Wrapper for portage
+    """
+    def __init__(self, logger):
+        ExternPackager.__init__(self, logger)
+        self.available = False
+        try:
+            from _emerge import search
+            from _emerge import actions
+            from _emerge.actions import load_emerge_config
+            self.portage = __import__('portage')
+            emerge_config = load_emerge_config()
+            self.root_config = emerge_config.running_config
+            # search init args:
+            # (self,root_config,spinner,searchdesc,verbose,usepkg,usepkgconly,search_index=True)
+            self.search = search.search(self.root_config,False,False,False,True,False)
+            self.search._vardb.cp_all()
+            self.available = True
+        except ImportError as e:
+            self.available = False
+
+    def get_available_version(self, pkgname):
+        """
+        Return a version that we can install through this package manager.
+        """
+        try:
+            ver = None
+            pkg = self.search._xmatch('bestmatch-visible',pkgname)
+            ver = self.portage.catpkgsplit(pkg, True)[2]
+            if ver:
+                self.log.debug("Package {} has version {} in portage".format(pkgname, ver))
+            return ver
+        except Exception as ex:
+            self.log.error("Error: {}".format(ex))
+        return False
+
+    def get_installed_version(self, pkgname):
+        """
+        Return the currently installed version. If pkgname is not installed,
+        return None.
+        """
+        try:
+            installed_package = self.search._vardb.match(pkgname)
+            if installed_package:
+                try:
+                    self._vardb.match_unordered
+                except AttributeError:
+                    installed_package = installed_package[-1]
+                else:
+                    installed_package = self.portage.best(installed_package)
+            else:
+                installed_package = ""
+            if installed_package:
+                ver = self.portage.catpkgsplit(installed_package,True)[2]
+                self.log.debug("Package {} has version {}".format(pkgname, ver))
+            else:
+                ver = None
+            #print('Portage ver: {}'.format(ver))
+            return ver
+        except Exception as ex:
+            self.log.error("Error: `{} ".format(ex))
+            self.log.obnoxious(str(ex))
+            return False
+
+    def install(self, pkgname):
+        """
+        pacman install pkgname
+        """
+        return NotImplementedError
+
+    def update(self, pkgname):
+        """
+        pacman update pkgname
+        """
+        return NotImplementedError
+
+class Portage(ExternCmdPackagerBase):
+    """
+     portage install xyz
+    """
+    name = 'portage'
+    pkgtype = 'portage'
+
+    def __init__(self):
+        ExternCmdPackagerBase.__init__(self)
+        self.packager = ExternalPortage(self.log)
+
+    def supported(self):
+        """
+        Check if we have portage python bindings.
+        Return True if so.
+        """
+        return self.packager.available

--- a/pybombs/recipe.py
+++ b/pybombs/recipe.py
@@ -93,7 +93,7 @@ class PBPackageRequirementScanner(object):
     # MatchObject, it has to match().
     lexicon = {
         # Package name
-        re.compile(r'[a-zA-Z-][a-zA-Z0-9.+_-]+'): lambda s, tok: s.pl_pkg(tok),
+        re.compile(r'[a-zA-Z-][a-zA-Z0-9./+_-]+'): lambda s, tok: s.pl_pkg(tok),
         # Version
         re.compile(r'[0-9]+[0-9.]*'): lambda s, tok: s.pl_ver(tok),
         # Open parens
@@ -114,7 +114,7 @@ class PBPackageRequirementScanner(object):
             self.log.obnoxious("Empty requirements string.")
             return
         lexer = shlex.shlex(req_string)
-        lexer.wordchars += '-<>=.&|'
+        lexer.wordchars += '-<>=.&|/'
         while True:
             token = lexer.get_token()
             if token == lexer.eof:

--- a/pybombs/utils/subproc.py
+++ b/pybombs/utils/subproc.py
@@ -137,7 +137,7 @@ def _process_thread(event, args, kwargs):
         if kwargs.get('shell', False) and isinstance(args, str):
             args = ' '.join(ELEVATE_PRE_ARGS) + args
         else:
-            args = ELEVATE_PRE_ARGS + args
+            args = ' '.join(ELEVATE_PRE_ARGS) + ' ' + args
     log = logger.getChild("_process_thread()")
     log.debug("Executing command `{cmd}'".format(cmd=str(args).strip()))
     proc = subprocess.Popen(


### PR DESCRIPTION
Searching for installed and available versions works. Installation of current stable version is possible and should resolve most dependencies. Handling for multiple versions can be implemented. E.g. select version with next bigger version number than required.

Searching is implemented using Python API of portage/emerge to make use of its python origin. Installation requires a lot of checks and is already implemented with `emerge`.
Subprocess of emerge is called with `shell=True` due to incorrect parsing of keyword arguments. Keyword arguments sent to emerge are recognized as package name.