### PR TITLE
Handle ssh location when using git.

### DIFF
--- a/pybombs/fetchers/git.py
+++ b/pybombs/fetchers/git.py
@@ -34,20 +34,14 @@ def parse_git_url(url, args):
     """
     - If a git rev is given in the URL, split that out and put it into the args
 
-    First handle a url of the form:
-        <username>@<IP|HOSTNAME>:</path/to/repo.git>@<commit|rev|tag>
+    Look for format:
+        <URL>@<commit|rev|tag>
 
-    If a URL of the above form isn't found, then proceed with extracting the
-    hash from the end of the URL when it is in a form similar to:
-        http://<IP|HOSTNAME>/<repo.git>@<commit|rev|tag>
+    <commit|rev|tag> cannot contain a ':' or whitespace.
     """
-    m = re.search(r'(\S*@\S*)@(\S*)', url)
+    m = re.search(r'(\S*)@((?!\S*[:*])\S*$)', url)
     if m:
         url, args['gitrev']  = (m.group(1), m.group(2))
-    else:
-        split_url_and_rev = re.split(r'@(?=[^:]+$)', url)
-        if len(split_url_and_rev) == 2:
-            url, args['gitrev'] = split_url_and_rev
     return url, args
 
 class Git(FetcherBase):

--- a/pybombs/fetchers/git.py
+++ b/pybombs/fetchers/git.py
@@ -33,10 +33,21 @@ from pybombs.pb_exception import PBException
 def parse_git_url(url, args):
     """
     - If a git rev is given in the URL, split that out and put it into the args
+
+    First handle a url of the form:
+        <username>@<IP|HOSTNAME>:</path/to/repo.git>@<commit|rev|tag>
+
+    If a URL of the above form isn't found, then proceed with extracting the
+    hash from the end of the URL when it is in a form similar to:
+        http://<IP|HOSTNAME>/<repo.git>@<commit|rev|tag>
     """
-    split_url_and_rev = re.split(r'@(?=[^:]+$)', url)
-    if len(split_url_and_rev) == 2:
-        url, args['gitrev'] = split_url_and_rev
+    m = re.search(r'(\S*@\S*)@(\S*)', url)
+    if m:
+        url, args['gitrev']  = (m.group(1), m.group(2))
+    else:
+        split_url_and_rev = re.split(r'@(?=[^:]+$)', url)
+        if len(split_url_and_rev) == 2:
+            url, args['gitrev'] = split_url_and_rev
     return url, args
 
 class Git(FetcherBase):


### PR DESCRIPTION
Commit https://github.com/gnuradio/pybombs/commit/e756d7f2a3b3f3c6f433561c77680b7e2bed74d7 fails to parse a location of the form:
```
pybombs recipes add <alias> git+<username>@<IP|HOSTNAME>:<path/to/repo.git>@<commit|rev|tag>
```
Please reopen #358

My regex foo isn't great, but this commit handles both (normal and SSH) cases.