### PR TITLE
packagers: pacman: change -Si to -Qi

### DIFF
--- a/pybombs/packagers/pacman.py
+++ b/pybombs/packagers/pacman.py
@@ -69,7 +69,7 @@ class ExternalPacman(ExternPackager):
             # '-Qi' will return non-zero if package does not exist, thus will throw
             # Output is sth like local/<pkgname> x.x.x.x-x
             ver = subproc.match_output(
-                [self.command, "-Si", pkgname],
+                [self.command, "-Qi", pkgname],
                 r'Version[ ]*: (?P<ver>[0-9,.]*)',
                 'ver'
             )


### PR DESCRIPTION
If looking for installed packages currently -Si parameter is used. But this only lists available packages for installation.