### PR TITLE
fetch.py: check if the attribute 'sources' is defined for the recipe before testing for its length

### DIFF
--- a/pybombs/commands/fetch.py
+++ b/pybombs/commands/fetch.py
@@ -84,7 +84,7 @@ class Fetch(CommandBase):
             self.log.error("Package has no recipe: {}".format(e))
             return 1
         for r in recipe_list:
-            if not len(r.source):
+            if (not hasattr(r,'source')) or (not len(r.source)):
                 self.log.warn("Package {0} has no sources listed.".format(r.id))
                 continue
             self.log.info("Downloading source for package {0}".format(r.id))


### PR DESCRIPTION
Check if the current recipe has a 'source' attribute set, before accessing it to test its length to establish it the source string is a nonempty URL.

This way, recipes which do not have a source field set issue a warning message, but do not raise an AttributeError exception, stopping the fetch for other packages:

Traceback (most recent call last):
  File "/usr/local/bin/pybombs", line 11, in <module>
    load_entry_point('PyBOMBS==2.1.1a0', 'console_scripts', 'pybombs')()
  File "/usr/local/lib/python2.7/dist-packages/pybombs/main.py", line 32, in main
    return dispatch() or 0
  File "/usr/local/lib/python2.7/dist-packages/pybombs/commands/base.py", line 188, in dispatch
    return get_cmd_dict(cmd_list)[args.command](cmd=args.command, args=args).run()
  File "/usr/local/lib/python2.7/dist-packages/pybombs/commands/fetch.py", line 87, in run
    if not len(r.source):
AttributeError: 'Recipe' object has no attribute 'source'