### PR TITLE
Fixed package name of build-essential, not build_essential.

### DIFF
--- a/pybombs/recipes/build-essential.lwr
+++ b/pybombs/recipes/build-essential.lwr
@@ -20,6 +20,6 @@
 inherit: empty
 category: baseline
 satisfy:
-  deb: build_essential || (make && (gcc || clang) && (g++ || clang))
+  deb: build-essential || (make && (gcc || clang) && (g++ || clang))
   rpm: make && (gcc || clang) && (gcc-c++ || clang)
   cmd: make --version && (gcc --version || clang --version) && (g++ --version || clang --version)


### PR DESCRIPTION
Revealed by new apt show error.