### PR TITLE
Implemented python-apt support for caching

### DIFF
--- a/pybombs/packagers/apt.py
+++ b/pybombs/packagers/apt.py
@@ -59,7 +59,7 @@ class ExternalApt(ExternPackager):
         Check which version is available.
         """
         if self.cache:
-            self.log.obnoxious("Checking apt for `{1}'".format(self.searchcmd, pkgname))
+            self.log.obnoxious("Checking apt for `{0}'".format(pkgname))
             (ver, is_installed) = self.check_cache(pkgname)
             if ver:
                 self.log.debug("Package {0} has version {1} in repositories".format(pkgname, ver))

--- a/pybombs/packagers/apt.py
+++ b/pybombs/packagers/apt.py
@@ -46,7 +46,7 @@ class ExternalApt(ExternPackager):
         try:
             import apt
             self.cache = apt.Cache()
-        except ImportError or AttributeError:
+        except (ImportError, AttributeError):
             # ImportError is caused by apt being completely missing
             # AttributeError is caused by us importing ourselves (we have no
             #   Cache() method) because python-apt is missing and we got a

--- a/pybombs/utils/utils.py
+++ b/pybombs/utils/utils.py
@@ -91,6 +91,14 @@ def md5sum(filename):
             hash_md5.update(buff)
     return hash_md5.hexdigest()
 
+def python_apt_import():
+    try:
+        import apt
+        return apt
+    except ImportError:
+        return None
+
+
 if __name__ == "__main__":
     print(dict_merge(
         {'a': 1, 'b': 2},

--- a/pybombs/utils/utils.py
+++ b/pybombs/utils/utils.py
@@ -91,14 +91,6 @@ def md5sum(filename):
             hash_md5.update(buff)
     return hash_md5.hexdigest()
 
-def python_apt_import():
-    try:
-        import apt
-        return apt
-    except ImportError:
-        return None
-
-
 if __name__ == "__main__":
     print(dict_merge(
         {'a': 1, 'b': 2},


### PR DESCRIPTION
Affects get_available_version() and get_installed_version() when python-apt is installed. Gracefully falls back to old approach otherwise. Displays a warning if python-apt is not installed.

Approximately 6.7x speedup of "pybombs recipes list" on my machine.

Note that I am unable to test on a machine that does not have Apt, so I'm not sure whether this gracefully handles that situation. Unsure if the warning will be displayed on non-Apt machines.

The unusual "python_apt_import" step is required because apt.py in this package conflicts with python-apt.