### PR TITLE
Replace the satisfy_order option with a stricter install procedure

### DIFF
--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -302,10 +302,6 @@ class ConfigManager(object):
     # Default values + Help text:
     defaults = {
         'default_prefix': ('', 'Default Prefix'),
-        'satisfy_order': (
-            'native, src',
-            'Order in which to attempt installations when available, options are: src, native'
-        ),
         'cmakebuildtype': (
             'RelWithDebInfo',
             'CMAKE_BUILD_TYPE args to pass to cmake projects, options are: Debug, Release, RelWithDebInfo, MinSizeRel'
@@ -652,12 +648,12 @@ class ConfigManager(object):
         return parser
 
 
-# This is what you want to use
+# This is what you want to use. Don't instantiate ConfigManager() yourself.
 config_manager = ConfigManager()
 
 # Some test code:
 if __name__ == "__main__":
-    print(config_manager.get_help("satisfy_order"))
-    print(config_manager.get("satisfy_order"))
-    config_manager.set("satisfy_order", "foo, bar")
-    print(config_manager.get("satisfy_order"))
+    print(config_manager.get_help("makewidth"))
+    print(config_manager.get("makewidth"))
+    config_manager.set("makewidth", "8")
+    print(config_manager.get("makewidth"))

--- a/pybombs/dep_manager.py
+++ b/pybombs/dep_manager.py
@@ -75,7 +75,7 @@ class DepManager(object):
         for dep in deps:
             if not self.pm.exists(pkg):
                 self.log.error(
-                    "Package has no install path: {0} (declared as dependency for package {1})".format(
+                    "Package has no install method: {0} (declared as dependency for package {1})".format(
                         dep, pkg
                     )
                 )

--- a/pybombs/packagers/source.py
+++ b/pybombs/packagers/source.py
@@ -49,9 +49,9 @@ class Source(PackagerBase):
 
     def supported(self):
         """
-        We can always build source packages unless disabled in the config.
+        We can always build source packages if there's a prefix
         """
-        return 'src' in self.cfg.get('satisfy_order')
+        return self.prefix.prefix_dir is not None
 
     def exists(self, recipe):
         """

--- a/pybombs/requirer.py
+++ b/pybombs/requirer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Free Software Foundation, Inc.
+# Copyright 2015-2016 Free Software Foundation, Inc.
 #
 # This file is part of PyBOMBS
 #
@@ -19,7 +19,7 @@
 # Boston, MA 02110-1301, USA.
 #
 """
-A requirer is a class that has requirements.
+A requirer is a class that itself has dependencies on packages.
 """
 
 import argparse
@@ -39,9 +39,6 @@ def require_hostsys_dependencies(deps):
         return
     from pybombs import install_manager
     from pybombs.config_manager import config_manager
-    s_order = config_manager.get('satisfy_order')
-    # These are host system dependencies, so disallow source package manager
-    config_manager.set('satisfy_order', 'native')
     REQUIRER_CHECKED_CACHE += deps_to_check
     install_manager.InstallManager().install(
             deps_to_check,
@@ -50,9 +47,8 @@ def require_hostsys_dependencies(deps):
             update_if_exists=False,
             quiet=True,
             print_tree=False,
+            install_type="binary", # Requirers may not request source packages
     )
-    # Restore previous settings
-    config_manager.set('satisfy_order', s_order)
 
 class Requirer(object):
     """
@@ -62,6 +58,9 @@ class Requirer(object):
     host_sys_deps = []
 
     def __init__(self):
+        # There's a pretty good reason assert_requirements() is not called
+        # here, in fact, it used to be, but I can't remember why not. Probably
+        # to avoid infinite loops.
         pass
 
     def assert_requirements(self, requirements=None):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,4 +6,4 @@ pylint -E pybombs \
 	--disable=no-member
 
 echo "Building source distribution package (sdist)..."
-python setup.py sdist
+python setup.py -q sdist

--- a/tests/run_docker_tests.sh
+++ b/tests/run_docker_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd docker/
+for i in *
+do
+


### PR DESCRIPTION
Following this commit, satisfy_order is ignored. PyBOMBS will now
always first install packages from binary sources unless told otherwise,
and then install all the source packages.