### PR TITLE
Packagers new zypper: Dockerfile

### DIFF
--- a/pybombs/packagers/zypper.py
+++ b/pybombs/packagers/zypper.py
@@ -166,7 +166,7 @@ class Zypper(ExternCmdPackagerBase):
 
     def supported(self):
         """
-        Check if we can even run yum or dnf.
+        Check if we can even run zypper.
         Return True if so.
         """
         return self.packager.command is not None

--- a/tests/docker/opensuse_tw/Dockerfile
+++ b/tests/docker/opensuse_tw/Dockerfile
@@ -1,0 +1,22 @@
+# Base image
+FROM opensuse:tumbleweed
+WORKDIR /pybombs
+
+# Minimal package installation
+RUN zypper refresh
+RUN zypper install -y --no-recommends python2-pip
+RUN zypper install -y --no-recommends tar
+
+# Install PyBOMBS using setuptools
+COPY PyBOMBS*.tar.gz /pybombs
+RUN tar zxf *.tar.gz
+RUN cd `ls --hide=*.gz` && python setup.py -q install
+
+# Install something
+RUN mkdir /prefix
+
+RUN cd /prefix
+# Disable sudo:
+RUN pybombs config elevate_pre_args ''
+RUN pybombs recipes add gr-recipes git+https://github.com/jaredd/gr-recipes.git
+RUN pybombs -v prefix init -a default -R gnuradio-default default


### PR DESCRIPTION
I added a Dockerfile that passes its build test and references the latest commit to the master branch of jaredd/gr-recipes which fixes a couple recipes.  Any commit to gnuradio/pybombs will require a change to the pybombs recipes on line 21, but should correspond to an update to gr-recipes from my master branch.