### PR TITLE
Added NoSource fake package manager

### DIFF
--- a/pybombs/package_manager.py
+++ b/pybombs/package_manager.py
@@ -66,10 +66,9 @@ class PackageManager(object):
         # Create a source package manager
         if self.prefix_available:
             self.src = packagers.Source()
-            self.prefix = self.cfg.get_active_prefix()
         else:
             self.log.debug("No prefix specified. Skipping source package manager.")
-            self.src = None
+            self.src = packagers.NoSource()
         # Create sorted list of binary package managers
         self.binary_pkgrs = packagers.filter_available_packagers(
             self.cfg.get('packagers'),

--- a/pybombs/packagers/__init__.py
+++ b/pybombs/packagers/__init__.py
@@ -33,5 +33,5 @@ from .portage import Portage
 from .port import Port
 from .zypper import Zypper
 from .pymod import PythonModule
-from .source import Source
+from .source import Source, NoSource
 from .yum import YumDnf

--- a/pybombs/packagers/source.py
+++ b/pybombs/packagers/source.py
@@ -398,3 +398,60 @@ class Source(PackagerBase):
         if cmd is not None:
             return cmd
         return recipe.get_command(cmd_idx)
+
+
+class NoSource(PackagerBase):
+    """
+    Fake Source package manager (if there's no prefix)
+    """
+    name = "source"
+
+    def __init__(self):
+        PackagerBase.__init__(self)
+
+    def supported(self):
+        """
+        We can never build source packages if there's no prefix
+        """
+        return False
+
+    def exists(self, recipe):
+        """
+        This will work whenever any sources are defined.
+        """
+        if not hasattr(recipe, 'source') or len(recipe.source) == 0:
+            return None
+        # Return a pseudo-version
+        # TODO check if we can get something better from the inventory
+        return True
+
+    def installed(self, recipe):
+        """
+        No prefix? Not installed.
+        """
+        return False
+
+    def install(self, recipe, static=False, update=False):
+        """
+        Don't call me.
+        """
+        assert False
+
+    def update(self, recipe):
+        """
+        Don't call me.
+        """
+        assert False
+
+    def uninstall(self, recipe):
+        """
+        Don't call me.
+        """
+        assert False
+
+    def verify(self, recipe, try_again=False):
+        """
+        Don't call me.
+        """
+        assert False
+


### PR DESCRIPTION
For the case where there's no prefix, we might still need someone who
speaks for source-only recipes.
This fixes the bug where users try and run 'pybombs recipes list'
without having a prefix.