### PR TITLE
fix package version resolution in portage for multiple available pack…

### DIFF
--- a/pybombs/packagers/portage.py
+++ b/pybombs/packagers/portage.py
@@ -56,14 +56,15 @@ class ExternalPortage(ExternPackager):
         try:
             ver = None
             pkg = []
-            self.search.searchre = self.re.compile(pkgname, self.re.I)
+            self.search.searchre = self.re.compile(pkgname+"$", self.re.I)
             for package in self.search._cp_all():
                 match_string = package[:]
                 if self.search.searchre.search(match_string):
                     pkg += [package]
             full_package = []
             for p in pkg:
-                full_package += [self.search._xmatch('bestmatch-visible',p)]
+                # match-visible always returns a list
+                full_package.extend(self.search._xmatch('match-visible',p))
             versions = []
             for p in full_package:
                 versions += [self.portage.catpkgsplit(p, True)[2]]


### PR DESCRIPTION
This should fix #468 and might prevent further issues from occurring. Currently portage is only listing the "best" match for a specific package. Tweaking the match level parameter of `_xmatch` will list all visible (not masked) versions in portage. This might introduce an issue if multiple versions are available and not yet installed and pybombs would have to select the most appropriate version thus the current `bestmatch-visible` approach. 
I also added a "$" to the package regex otherwise we might match unwanted packages.