### PR TITLE
gitcache_manager: Use git config to fetch remote url

### DIFF
--- a/pybombs/gitcache_manager.py
+++ b/pybombs/gitcache_manager.py
@@ -55,7 +55,7 @@ class GitCacheManager(object):
         " Return dict remotename->url from current git repo "
         all_remotes = [x.strip() for x in self.run_git_command(['remote']).split()]
         return {
-            remote: self.run_git_command(['remote', 'get-url', remote]).strip()
+            remote: self.run_git_command(['config', '--get', "remote.%s.url" % remote]).strip()
             for remote in all_remotes
         }
 


### PR DESCRIPTION
Allows use of git pre-2.7 in addition to latest versions

Fixes #473