### PR TITLE
dont select wrong packages in portage

### DIFF
--- a/pybombs/packagers/portage.py
+++ b/pybombs/packagers/portage.py
@@ -56,7 +56,7 @@ class ExternalPortage(ExternPackager):
         try:
             ver = None
             pkg = []
-            self.search.searchre = self.re.compile(pkgname, self.re.I)
+            self.search.searchre = self.re.compile(pkgname+"$", self.re.I)
             for package in self.search._cp_all():
                 match_string = package[:]
                 if self.search.searchre.search(match_string):


### PR DESCRIPTION
if is the selected packename is a part other packagenames, pybombs get wrong version numbers. 

i only have python 3.4.5 installed and get this output.

> PyBOMBS.Packager.portage - DEBUG - Package dev-lang/python has versions 3.4.5, 2.4.4 in portage
PyBOMBS.PackageManager - DEBUG - Package python is not installable.
PyBOMBS.install_manager - ERROR - Package has no install method: python
> 


 