### PR TITLE
recipes: Added python2-devel to Fedora package list

### DIFF
--- a/pybombs/recipes/python.lwr
+++ b/pybombs/recipes/python.lwr
@@ -21,7 +21,7 @@ category: baseline
 inherit: autoconf
 satisfy:
   deb: python2.7 && python-dev
-  rpm: python-devel >= 2.7
+  rpm: python-devel >= 2.7 || python2-devel >= 2.7
   cmd: python --version >= 2.7
   pacman: python2 >= 2.7
   port: python27 >= 2.7


### PR DESCRIPTION
Fedora 26 provides only python2-devel and python3-devel packages