### PR TITLE
Return a failing exit code if install fails

### DIFF
--- a/pybombs/commands/install.py
+++ b/pybombs/commands/install.py
@@ -109,7 +109,8 @@ class Install(CommandBase):
 
     def run(self):
         """ Go, go, go! """
-        self.install_manager.install(
+        # Return False (0) on success, as it gets sent to exit()
+        return not self.install_manager.install(
                 self.args.packages,
                 mode=self.cmd,
                 fail_if_not_exists=self.fail_if_not_exists,


### PR DESCRIPTION
As it stands, `pybombs install ...` will always return a sucessful error code, even if it fails, which breaks assumptions about how any program is run. This simply passes back an appropriate error code