### PR TITLE
Added -E flag to default elevated arguments (proxy support)

### DIFF
--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -302,7 +302,7 @@ class ConfigManager(object):
         # The following line must always list *all* available packagers in order of priority:
         'packagers': ('apt,yumdnf,port,brew,zypper,pacman,portage,pymod,pip,pkgconfig,cmd', 'Priority of non-source package managers'),
         'keep_builddir': ('', 'When rebuilding, default to keeping the build directory'),
-        'elevate_pre_args': (['sudo', '-H'], 'For commands that need elevated privileges, prepend this'),
+        'elevate_pre_args': (['sudo', '-H', '-E'], 'For commands that need elevated privileges, prepend this'),
         'git-cache': (None, 'Path to git reference repository (git cache)'),
     }
     LAYER_DEFAULT = 0


### PR DESCRIPTION
This pull request is to include the `-E` by default as an elevated argument.

I had a really difficult time installing gnuradio with pybombs because I'm behind a corporate proxy with some wonky settings. After digging around in the source code I was eventually able to figure out I just needed to set the `-E` in pybombs config file to ensure that my `http_proxy`, `https_proxy`, and `ftp_proxy` variables got copied into calls to `sudo apt install`. 

I'm not intimately familiar with the potential dangers of passing the `-E` flag by default, but this seems like a simple change that could save some people a lot of hassle. What are your thoughts?