### PR TITLE
fix python3 compatibility problem

### DIFF
--- a/pybombs/fetchers/git.py
+++ b/pybombs/fetchers/git.py
@@ -53,7 +53,7 @@ def get_git_version():
     try:
         return re.search(
             r'[0-9.]+',
-            subprocess.check_output(['git', '--version'])
+            subprocess.check_output(['git', '--version']).decode('ascii')
         ).group(0)
     except OSError:
         raise PBException("Unable to execute git!")


### PR DESCRIPTION
fix python3 compatibility problem

> TypeError: cannot use a string pattern on a bytes-like object

when run command `pybombs recipes add-defaults`

refer to: https://www.mail-archive.com/discuss-gnuradio@gnu.org/msg66042.html  

tested on archlinux, python2 & python3