### PR TITLE
Fixed broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyBOMBS
 
-Website: https://www.gnuradio.org/blog/pybombs-the-what-the-how-and-the-why/
+Website: https://www.gnuradio.org/blog/pybombs-the-what-the-how-and-the-why
 
 Minimum Python version: 2.7
 


### PR DESCRIPTION
The ending forward slash would cause you to be redirected to a 404 error page.