### PR TITLE
Update debian.md

### DIFF
--- a/debian.md
+++ b/debian.md
@@ -1,4 +1,4 @@
-# Using PyBOMBS on CentOS
+# Using PyBOMBS on Debian
 
 ## Debian Jessie
 


### PR DESCRIPTION
The H1 header was "Using PyBOMBS on CentOS" instead of "Using PyBOMBS on Debian".