### PR TITLE
build doxygen set to true by default

### DIFF
--- a/pybombs/config_manager.py
+++ b/pybombs/config_manager.py
@@ -297,7 +297,7 @@ class ConfigManager(object):
             'RelWithDebInfo',
             'CMAKE_BUILD_TYPE args to pass to cmake projects, options are: Debug, Release, RelWithDebInfo, MinSizeRel'
         ),
-        'builddocs': ('OFF', 'Build doxygen while compiling packages? options are: ON, OFF'),
+        'builddocs': ('ON', 'Build doxygen while compiling packages? options are: ON, OFF'),
         'makewidth': ('4', 'Concurrent make threads [1,2,4,8...]'),
         # The following line must always list *all* available packagers in order of priority:
         'packagers': ('apt,yumdnf,port,brew,zypper,pacman,portage,pymod,pip,pkgconfig,cmd', 'Priority of non-source package managers'),


### PR DESCRIPTION
We were having an issue where people weren't seeing anything in the documentation tab of a block in GRC, and it turns out it's because this was disabled by default.  Yes I know you can enable doxygen with a flag, but so many people are using pybombs with the standard "pybombs install gnuradio" as their go-to method for new installs, and it makes GR seem less mature when the documentation tabs are empty.

Let me know if it makes more sense to change gnuradio.lwr instead of this. 