### PR TITLE
fixes issue #517 pybombs assumed dict and list instances

### DIFF
--- a/pybombs/recipe.py
+++ b/pybombs/recipe.py
@@ -26,6 +26,11 @@ import re
 import os
 import shlex
 from six import iteritems
+try:
+     from collections.abc import Sequence
+except ImportError:
+     from collections import Sequence
+
 
 from pybombs import pb_logging
 from pybombs import recipe_manager
@@ -256,8 +261,10 @@ class Recipe(object):
         data = PBConfigFile(filename).get()
         # Make sure dependencies is always a valid list:
         if 'depends' in data and data['depends'] is not None:
-            if not isinstance(data['depends'], list):
+            if not isinstance(data['depends'], Sequence):
                 data['depends'] = [data['depends'], ]
+            else:
+                data['depends'] = list(data['depends'])  # not every Sequence is a list
         else:
             data['depends'] = []
         return data

--- a/pybombs/utils/utils.py
+++ b/pybombs/utils/utils.py
@@ -26,16 +26,20 @@ import sys
 from copy import deepcopy
 from six import iteritems
 from builtins import input
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 def dict_merge(a, b):
     """
     Recursively merge b into a. b[k] will overwrite a[k] if it exists.
     """
-    if not isinstance(b, dict):
+    if not isinstance(b, Mapping):
         return b
     result = deepcopy(a)
     for k, v in iteritems(b):
-        if k in result and isinstance(result[k], dict):
+        if k in result and isinstance(result[k], Mapping):
             result[k] = dict_merge(result[k], v)
         else:
             result[k] = deepcopy(v)


### PR DESCRIPTION
ruamel.yaml recently changed from subclassing ``dict`` and ``list`` for resp. ``CommentedMap`` and ``CommentedList``. 

At two places ``ininstance`` checks were made against ``dict`` and ``list`` that no did see the YAML loaded data as such. Since ``list`` is registered as a ``MutableSequence`` and ``dict`` as a ``MutableMapping`` it is much more appropriate to test against those, or even to there parents (if you only read from the first parameter to ``isinstance`` anyway).

AFAIK ``six`` doesn't give you these abstract base classes, hence the ``try`` (failing on Python < 3).