### PR TITLE
Add GRC environment variables into the setup.env

### DIFF
--- a/pybombs/templates/prefix.lwt
+++ b/pybombs/templates/prefix.lwt
@@ -32,6 +32,8 @@ files:
         export LIBRARY_PATH="$prefix/lib:$prefix/lib64/:$LIBRARY_PATH"
         export PKG_CONFIG_PATH="$prefix/lib/pkgconfig:$prefix/lib64/pkgconfig:$PKG_CONFIG_PATH"
         export PYBOMBS_PREFIX="$prefix"
+        export GRC_PREFS_PATH="$prefix/.gnuradio"
+        export GRC_HIER_PATH="$prefix/share/gnuradio/grc/hier_blocks"
         # If we're in a Python virtualenv, activate that
         if [ -r $prefix/bin/activate ]; then
             source $prefix/bin/activate


### PR DESCRIPTION
In cases where users have multiple pybombs prefixes, keeping the hier
blocks and the grc prefs file local to the prefix prevents some issues

There is more work to be done with the gnuradio prefs location and structure, 
but this one seems like low hanging fruit since these env vars are already
in grc.