### PR TITLE
Fix broken CI

### DIFF
--- a/pybombs/config_file.py
+++ b/pybombs/config_file.py
@@ -56,10 +56,7 @@ class AbstractYaml(object):
 
     def dump(self, data, out):
         """Dump contents of a dictionary"""
-        if yaml.version_info[0] >= 0 and yaml.version_info[1] >= 15:
-            return self._dump(data, out)
-        else:
-            return self._dump(data, out, default_flow_style=False)
+        return self._dump(data, out)
 
 
 

--- a/pybombs/config_file.py
+++ b/pybombs/config_file.py
@@ -42,7 +42,7 @@ class AbstractYaml(object):
     YAML version.
     """
     def __init__(self):
-        if yaml.version_info[0] >= 0 and yaml.version_info[1] >= 15:
+        if yaml.version_info >= (0, 15):
             self.yaml = yaml.YAML(typ='rt')
             self.yaml.default_flow_style = False
             self._load = self.yaml.load


### PR DESCRIPTION
Travis CI began failing in 4cbdab04741e0735f0db697fd9a79a3ee1c0089e due to the following pylint error:
```
************* Module pybombs.config_file
E: 62,19: Unexpected keyword argument 'default_flow_style' in method call (unexpected-keyword-arg)
```

It seems pylint is confused because `AbstractYaml.__init__` may leave `_dump` uninitialized. In any case, 4cbdab04741e0735f0db697fd9a79a3ee1c0089e made it impossible to reach the problematic `else` clause in `AbstractYaml.dump`, so we can simply remove the whole `if` statement.

I also noticed that ruamel version check was broken; it requires the minor version number to be at least 15, and so it would incorrectly reject things like versions 1.0 through 1.14 (if they were to appear in the future). I simplified the check to compare against the tuple (0, 15), which should correctly compare version numbers.