### PR TITLE
Dockerfile for testing Ubuntu 20.04

### DIFF
--- a/tests/docker/ubuntu_2004/Dockerfile
+++ b/tests/docker/ubuntu_2004/Dockerfile
@@ -1,0 +1,33 @@
+# Base image
+FROM ubuntu:20.04
+WORKDIR /pybombs
+
+# Some packages depend on tzdata, which gets stuck if timezone is not set.
+# overrideable during build using `--build-arg TZ=America/New_York`.
+ARG TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Minimal package installation
+RUN apt-get update -qq -y
+# ruamel will get installed by setup.py via pip, but this just makes the
+# process smoother
+RUN apt-get install -qq -y python3-pip
+RUN apt-get install -qq -y python3-ruamel.yaml
+
+# Some pybombs install steps will fail without pkg-config installed.
+# TODO: should probably go into the deps of respective recipes?
+RUN apt-get install -qq -y pkg-config
+
+# Install PyBOMBS using setuptools
+COPY PyBOMBS*.tar.gz /pybombs
+RUN tar zxf *.tar.gz
+RUN cd * && python3 setup.py install -q
+
+# Install something
+RUN mkdir /prefix
+RUN cd /prefix
+RUN pybombs -v auto-config
+RUN pybombs -v recipes add-defaults
+RUN pybombs -v prefix init -a default default
+RUN pybombs install gr-osmosdr
+


### PR DESCRIPTION
Here is a minimal docker build using Ubuntu 20.04.

It is derived from the [ubuntu_1804_py3k image](https://github.com/gnuradio/pybombs/blob/master/tests/docker/ubuntu_1804_py3k/Dockerfile), i.e., it uses Python 3 by default.

Builds fine for me, but only after adding an `apt-get install -qq -y pkg-config` line. Otherwise, installation of gr-osmosdr fails during the installation of airspy. Not sure if this should be upstreamed into the airspy.lwr as a dependency? Some context:
* just installing `pybombs install airspy` on a fresh Ubuntu 18.04 will fail with the same issue, however installing `pybombs install gr-osmosdr` works fine (probably because pkg-config gets installed somewhere during the tree installation before airspy gets installed
* Not sure how deterministic tree resolution is, but the previous point sounds to me like pkg-config should be listed in the airspy recipe dependencies?

I have added fixes to that recipe (see gnuradio/gr-recipes#195 / gnuradio/gr-recipes#196), but I'm unsure if airspy was a lucky find or if other recipes may also fail if this is removed (didn't try them all individually, let me know if you'd like me to).