### PR TITLE
travis: add newer Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install --upgrade setuptools
   - pip install .


### PR DESCRIPTION
We may as well test PyBOMBS against Python 3.7 and 3.8. I've done that here, and will merge if Travis is happy.