### PR TITLE
In utils/subproc.py: Change threading.Thread monitor_thread method isAlive to is_alive

### DIFF
--- a/pybombs/utils/subproc.py
+++ b/pybombs/utils/subproc.py
@@ -240,7 +240,7 @@ def monitor_process(args, **kwargs):
             args=(quit_event, args, kwargs)
         )
         monitor_thread.start()
-        while monitor_thread.isAlive:
+        while monitor_thread.is_alive:
             # Try if it's finished:
             monitor_thread.join(1)
             if quit_event.is_set() or not monitor_thread.is_alive():

--- a/pybombs/utils/subproc.py
+++ b/pybombs/utils/subproc.py
@@ -240,7 +240,7 @@ def monitor_process(args, **kwargs):
             args=(quit_event, args, kwargs)
         )
         monitor_thread.start()
-        while monitor_thread.is_alive:
+        while monitor_thread.is_alive():
             # Try if it's finished:
             monitor_thread.join(1)
             if quit_event.is_set() or not monitor_thread.is_alive():


### PR DESCRIPTION
Under Python3, when I tried the command
`pybombs recipes add-defaults`
I got an error raised in <python3-dir>/pybombs/utils/subproc.py:
```
File "/usr/local/lib/python3.9/site-packages/pybombs/utils/subproc.py", line 243, in monitor_process
    while monitor_thread.isAlive:
AttributeError: 'Thread' object has no attribute 'isAlive'
```
The simple fix was to change the method called isAlive to is_alive, as that was changed in python3.  The command to add the default recipes worked after this fix.