### PR TITLE
Fix deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
This addresses the following warning identified in CI:

> UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead