### PR TITLE
Fixes File fetcher error due to Python 3 changes

### DIFF
--- a/pybombs/fetchers/file.py
+++ b/pybombs/fetchers/file.py
@@ -53,7 +53,7 @@ class File(FetcherBase):
         else:
             self.log.debug("Symlinking file to source dir.")
             os.symlink(url, os.path.join(os.getcwd(), filename))
-        if args.has_key("md5"):
+        if "md5" in args:
             self.log.debug("Calculating MD5 sum for {0}...".format(filename))
             actual_md5 = utils.md5sum(filename)
             if actual_md5 != args["md5"]:


### PR DESCRIPTION
Use of the file fetcher caused the following error due to the
deprecation of 'has_key' in Python 3. This uses the Python 3 syntax.

[ERROR] 'collections.OrderedDict' object has no attribute 'has_key'